### PR TITLE
update default port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
         - curl https://raw.githubusercontent.com/src-d/lookout-sdk/master/_tools/install-lookout-latest.sh | bash
         - (python3 -u sonarcheck_analyzer.py |& tee -a ../analyzer.log)&
         - sleep 5s
-        - ./lookout-sdk review --log-level=debug "ipv4://localhost:2022"
+        - ./lookout-sdk review --log-level=debug
 
     - name: 'Push image to Docker Hub'
       stage: release

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With `lookout-sdk` binary from the latest release of [SDK](https://github.com/sr
 ```
 $ python3 lookout-sonarcheck.py
 
-$ lookout-sdk review -v ipv4://localhost:2001 \
+$ lookout-sdk review --log-level=debug \
     --from c99dcdff172f1cb5505603a45d054998cb4dd606 \
     --to 3a9d78bdd1139c929903885ecb8f811931b8aa70
 ```
@@ -23,7 +23,7 @@ $ lookout-sdk review -v ipv4://localhost:2001 \
 | Variable | Default | Description |
 | -- | -- | -- |
 | `SONARCHECK_HOST` | `0.0.0.0` | IP address to bind the gRPC serve |
-| `SONARCHECK_PORT` | `2002` | Port to bind the gRPC server |
+| `SONARCHECK_PORT` | `9930` | Port to bind the gRPC server |
 | `SONARCHECK_DATA_SERVICE_URL` | `ipv4://localhost:10301` | gRPC URL of the [Data service](https://github.com/src-d/lookout/tree/master/docs#components)
 | `SONARCHECK_LOG_LEVEL` | `info` | Logging level (info, debug, warning or error) |
 

--- a/sonarcheck_analyzer.py
+++ b/sonarcheck_analyzer.py
@@ -21,7 +21,7 @@ from bblfsh import filter as filter_uast
 
 version = "alpha"
 host_to_bind = os.getenv('SONARCHECK_HOST', "0.0.0.0")
-port_to_listen = os.getenv('SONARCHECK_PORT', 2022)
+port_to_listen = os.getenv('SONARCHECK_PORT', 9930)
 data_srv_addr = to_grpc_address(
     os.getenv('SONARCHECK_DATA_SERVICE_URL', "ipv4://localhost:10301"))
 log_level = os.getenv('SONARCHECK_LOG_LEVEL', "info").upper()


### PR DESCRIPTION
CI suppose to fail as long as we don't release new sdk version.
It's done intentionally to make sure default in sdk and in the analyzer are the same.

Ref: https://github.com/src-d/lookout/issues/350

Signed-off-by: Maxim Sukharev <max@smacker.ru>