### PR TITLE
Use make docker-push-latest-release to skip latest tag on pre-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 'Push image to Docker Hub'
       stage: release
       script:
-        - DOCKER_PUSH_LATEST=true make docker-push
+        - make docker-push-latest-release
 
     - name: 'Deploy to staging'
       stage: deploy


### PR DESCRIPTION
Otherwise a pre-release will tag the docker image as latest.