### PR TITLE
Update travis badge to new .com url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![Build Status](https://travis-ci.org/src-d/lookout-sonarcheck-analyzer.svg)](https://travis-ci.org/src-d/lookout-sonarcheck-analyzer) lookout analyzer: sonarcheck
+# [![Build Status](https://travis-ci.com/src-d/lookout-sonarcheck-analyzer.svg?branch=master)](https://travis-ci.com/src-d/lookout-sonarcheck-analyzer) lookout analyzer: sonarcheck
 
 A [lookout](https://github.com/src-d/lookout/) analyzer implementation that uses bblfsh UAST and [sonar-checks](https://github.com/bblfsh/sonar-checks).
 


### PR DESCRIPTION
The current badge does not report the build status correctly, and links to travis.org, which is not where the build happen anymore.