### PR TITLE
Add exception handling

### DIFF
--- a/sonarcheck_analyzer.py
+++ b/sonarcheck_analyzer.py
@@ -78,13 +78,18 @@ class Analyzer(pb.AnalyzerServicer):
                                      change.head.path, request.commit_revision.head.hash, e)
                     continue
 
+                logger.debug("check_results %s", check_results)
                 for check in check_results:
                     for res in check_results[check]:
-                        comments.append(
-                            pb.Comment(
-                                file=change.head.path,
-                                line=(res.get("pos", {}) or {}).get("line", 0),
-                                text="{}: {}".format(check, res["msg"])))
+                        try:
+                            comments.append(
+                                pb.Comment(
+                                    file=change.head.path,
+                                    line=(res.get("pos", {}) or {}).get("line", 0),
+                                    text="{}: {}".format(check, res["msg"])))
+                        except Exception as e:
+                            logger.exception("Error occurred while creating a comment: %s", e)
+                            continue
 
         logger.info("%d comments produced", len(comments))
 


### PR DESCRIPTION
For instance, check result like 'RSPEC-2176': [{'msg': 'Class has same name as parent', 'pos': None}] throws exception and since exception is not caught none of the comments get posted. It took me quite some time to figure out what was wrong. 